### PR TITLE
Epic 3: Dynamic Detail View with Markdown Transclusion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:2.3.7")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.7")
 
+    implementation("com.vladsch.flexmark:flexmark-all:0.64.8")
+    implementation("net.sourceforge.plantuml:plantuml:1.2023.12")
+
     implementation("org.jetbrains.jewel:jewel-ide-laf-bridge-243:0.27.0")
     api(compose.desktop.currentOs) {
         exclude(group = "org.jetbrains.compose.material")

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -8,12 +8,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.devfastjavafx.cache.TemplateCache
+import com.example.devfastjavafx.ui.markdown.MarkdownParser
+import com.example.devfastjavafx.ui.markdown.MarkdownRenderer
+import com.intellij.openapi.application.PathManager
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.HorizontalSplitLayout
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.rememberSplitLayoutState
-import java.io.File
+import java.nio.file.Paths
 
 @Composable
 fun DevFastToolWindowContent() {
@@ -52,25 +55,25 @@ fun DevFastToolWindowContent() {
             }
         },
         second = {
-            Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-                if (selectedComponent != null) {
-                    Text(text = "Component: $selectedComponent")
-                    Spacer(modifier = Modifier.height(8.dp))
+            if (selectedComponent != null) {
+                val componentDirPath = Paths.get(PathManager.getSystemPath(), "devFastJavaFx/templates", selectedComponent!!)
+                val markdownParser = remember(selectedComponent) { MarkdownParser(componentDirPath) }
 
-                    val readmePath = allFiles.find { it.contains(selectedComponent!!) && it.endsWith("README.md") }
-                    if (readmePath != null) {
-                        val readmeContent = TemplateCache.loadTemplate(readmePath)
-                        if (readmeContent != null) {
-                            Text(text = "Description:")
-                            Text(text = readmeContent)
-                        }
-                    } else {
-                        Text(text = "No README.md found for this component.")
+                val readmePath = allFiles.find { it.contains(selectedComponent!!) && it.endsWith("README.md") }
+                if (readmePath != null) {
+                    val readmeContent = TemplateCache.loadTemplate(readmePath)
+                    if (readmeContent != null) {
+                        val blocks = remember(readmeContent) { markdownParser.parse(readmeContent) }
+                        MarkdownRenderer(blocks)
                     }
                 } else {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
-                        Text(text = "Select a component to see details")
+                    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                        Text(text = "No README.md found for component: $selectedComponent")
                     }
+                }
+            } else {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                    Text(text = "Select a component to see details")
                 }
             }
         }

--- a/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownBlock.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownBlock.kt
@@ -1,0 +1,12 @@
+package com.example.devfastjavafx.ui.markdown
+
+import androidx.compose.ui.text.AnnotatedString
+
+sealed class MarkdownBlock {
+    data class Heading(val text: String, val level: Int) : MarkdownBlock()
+    data class Text(val content: AnnotatedString) : MarkdownBlock()
+    data class Code(val filename: String, val content: String, val language: String) : MarkdownBlock()
+    data class PlantUML(val filename: String, val content: String) : MarkdownBlock()
+    data class Image(val url: String, val altText: String? = null) : MarkdownBlock()
+    data class Error(val message: String) : MarkdownBlock()
+}

--- a/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownParser.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownParser.kt
@@ -1,0 +1,131 @@
+package com.example.devfastjavafx.ui.markdown
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import com.vladsch.flexmark.ast.*
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.ast.Node
+import com.vladsch.flexmark.util.data.MutableDataSet
+import java.nio.file.Files
+import java.nio.file.Path
+
+class MarkdownParser(private val componentDirectory: Path) {
+
+    private val parser: Parser = Parser.builder(MutableDataSet()).build()
+
+    fun parse(markdown: String): List<MarkdownBlock> {
+        val document = parser.parse(markdown)
+        val blocks = mutableListOf<MarkdownBlock>()
+
+        var node = document.firstChild
+        while (node != null) {
+            visitNode(node, blocks)
+            node = node.next
+        }
+
+        return blocks
+    }
+
+    private fun visitNode(node: Node, blocks: MutableList<MarkdownBlock>) {
+        when (node) {
+            is Heading -> {
+                blocks.add(MarkdownBlock.Heading(node.text.toString(), node.level))
+            }
+            is Paragraph -> {
+                val text = node.chars.toString().trim()
+                when {
+                    text.startsWith("@[code](") && text.endsWith(")") -> {
+                        val filename = text.substringAfter("@[code](").substringBeforeLast(")")
+                        blocks.add(resolveCodeBlock(filename))
+                    }
+                    text.startsWith("@[plantuml](") && text.endsWith(")") -> {
+                        val filename = text.substringAfter("@[plantuml](").substringBeforeLast(")")
+                        blocks.add(resolvePlantUmlBlock(filename))
+                    }
+                    else -> {
+                        blocks.add(MarkdownBlock.Text(renderInlines(node)))
+                    }
+                }
+            }
+            is FencedCodeBlock -> {
+                blocks.add(MarkdownBlock.Code("In-line code", node.contentChars.toString(), node.info.toString()))
+            }
+            is Image -> {
+                blocks.add(MarkdownBlock.Image(node.url.toString(), node.title.toString()))
+            }
+            is BulletList, is OrderedList -> {
+                blocks.add(MarkdownBlock.Text(renderInlines(node)))
+            }
+            else -> {
+                val text = node.chars.toString()
+                if (text.isNotBlank()) {
+                    blocks.add(MarkdownBlock.Text(AnnotatedString(text)))
+                }
+            }
+        }
+    }
+
+    private fun renderInlines(node: Node): AnnotatedString = buildAnnotatedString {
+        var child = node.firstChild
+        while (child != null) {
+            when (child) {
+                is Text -> append(child.chars.toString())
+                is Emphasis -> withStyle(style = SpanStyle(fontStyle = FontStyle.Italic)) {
+                    append(renderInlines(child))
+                }
+                is StrongEmphasis -> withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(renderInlines(child))
+                }
+                is Code -> withStyle(style = SpanStyle(background = Color.LightGray)) {
+                    append(child.chars.toString())
+                }
+                is SoftLineBreak, is HardLineBreak -> append("\n")
+                else -> append(child.chars.toString())
+            }
+            child = child.next
+        }
+    }
+
+    private fun resolveCodeBlock(filename: String): MarkdownBlock {
+        val safePath = validatePath(filename) ?: return MarkdownBlock.Error("Invalid file path: $filename")
+        return if (Files.exists(safePath)) {
+            try {
+                val content = Files.readString(safePath)
+                val extension = filename.substringAfterLast(".", "txt")
+                MarkdownBlock.Code(filename, content, extension)
+            } catch (e: Exception) {
+                MarkdownBlock.Error("Error reading file $filename: ${e.message}")
+            }
+        } else {
+            MarkdownBlock.Error("File not found: $filename")
+        }
+    }
+
+    private fun resolvePlantUmlBlock(filename: String): MarkdownBlock {
+        val safePath = validatePath(filename) ?: return MarkdownBlock.Error("Invalid file path: $filename")
+        return if (Files.exists(safePath)) {
+            try {
+                val content = Files.readString(safePath)
+                MarkdownBlock.PlantUML(filename, content)
+            } catch (e: Exception) {
+                MarkdownBlock.Error("Error reading file $filename: ${e.message}")
+            }
+        } else {
+            MarkdownBlock.Error("File not found: $filename")
+        }
+    }
+
+    private fun validatePath(filename: String): Path? {
+        val resolvedPath = componentDirectory.resolve(filename).normalize()
+        return if (resolvedPath.startsWith(componentDirectory.normalize())) {
+            resolvedPath
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownRenderer.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownRenderer.kt
@@ -1,0 +1,191 @@
+package com.example.devfastjavafx.ui.markdown
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asComposeImageBitmap
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.sourceforge.plantuml.FileFormat
+import net.sourceforge.plantuml.FileFormatOption
+import net.sourceforge.plantuml.SourceStringReader
+import org.jetbrains.jewel.ui.component.ActionButton
+import org.jetbrains.jewel.ui.component.Text
+import java.io.ByteArrayOutputStream
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Image as SkiaImage
+import com.intellij.openapi.ide.CopyPasteManager
+import java.awt.datatransfer.StringSelection
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.ProjectManager
+
+@Composable
+fun MarkdownRenderer(blocks: List<MarkdownBlock>) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(blocks) { block ->
+            when (block) {
+                is MarkdownBlock.Heading -> HeadingBlock(block)
+                is MarkdownBlock.Text -> TextBlock(block)
+                is MarkdownBlock.Code -> CodeBlock(block)
+                is MarkdownBlock.PlantUML -> PlantUMLBlock(block)
+                is MarkdownBlock.Image -> ImageBlock(block)
+                is MarkdownBlock.Error -> ErrorBlock(block)
+            }
+        }
+    }
+}
+
+@Composable
+fun HeadingBlock(block: MarkdownBlock.Heading) {
+    val fontSize = when (block.level) {
+        1 -> 24.sp
+        2 -> 20.sp
+        3 -> 18.sp
+        else -> 16.sp
+    }
+    Text(
+        text = block.text,
+        fontSize = fontSize,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(vertical = 4.dp)
+    )
+}
+
+@Composable
+fun TextBlock(block: MarkdownBlock.Text) {
+    Text(text = block.content)
+}
+
+@Composable
+fun CodeBlock(block: MarkdownBlock.Code) {
+    val annotatedContent = remember(block.content, block.language) {
+        highlightCode(block.content, block.language)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFF2B2B2B), RoundedCornerShape(4.dp))
+            .padding(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(text = block.filename, color = Color.Gray, fontSize = 12.sp)
+            Row {
+                ActionButton(onClick = {
+                    CopyPasteManager.getInstance().setContents(StringSelection(block.content))
+                }) {
+                    Text("Copy")
+                }
+                Spacer(modifier = Modifier.width(4.dp))
+                ActionButton(onClick = {
+                    val project = ProjectManager.getInstance().openProjects.firstOrNull() ?: return@ActionButton
+                    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@ActionButton
+                    val document = editor.document
+                    val caretModel = editor.caretModel
+                    val offset = caretModel.offset
+
+                    WriteCommandAction.runWriteCommandAction(project) {
+                        document.insertString(offset, block.content)
+                    }
+                }) {
+                    Text("Insert")
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = annotatedContent,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 13.sp
+        )
+    }
+}
+
+fun highlightCode(content: String, language: String): AnnotatedString = buildAnnotatedString {
+    val keywords = setOf("class", "public", "private", "protected", "fun", "val", "var", "import", "package", "if", "else", "for", "while", "return", "void", "static")
+    val stringColor = Color(0xFF6A8759)
+    val keywordColor = Color(0xFFCC7832)
+    val commentColor = Color(0xFF808080)
+    val defaultColor = Color(0xFFA9B7C6)
+
+    val regex = Regex("""("[^"]*"|//.*|/\*.*?\*/|\b\w+\b|\s+|.)""", RegexOption.DOT_MATCHES_ALL)
+
+    regex.findAll(content).forEach { match ->
+        val text = match.value
+        when {
+            text.startsWith("\"") -> withStyle(style = SpanStyle(color = stringColor)) { append(text) }
+            text.startsWith("//") || text.startsWith("/*") -> withStyle(style = SpanStyle(color = commentColor)) { append(text) }
+            keywords.contains(text) -> withStyle(style = SpanStyle(color = keywordColor, fontWeight = FontWeight.Bold)) { append(text) }
+            else -> withStyle(style = SpanStyle(color = defaultColor)) { append(text) }
+        }
+    }
+}
+
+@Composable
+fun PlantUMLBlock(block: MarkdownBlock.PlantUML) {
+    val imageBitmap = remember(block.content) {
+        try {
+            val reader = SourceStringReader(block.content)
+            val os = ByteArrayOutputStream()
+            reader.outputImage(os, FileFormatOption(FileFormat.PNG))
+            val bytes = os.toByteArray()
+            val skiaImage = SkiaImage.makeFromEncoded(bytes)
+            val bitmap = Bitmap.makeFromImage(skiaImage)
+            bitmap.asComposeImageBitmap()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "Diagram: ${block.filename}", fontWeight = FontWeight.SemiBold)
+        if (imageBitmap != null) {
+            Image(
+                bitmap = imageBitmap,
+                contentDescription = block.filename,
+                modifier = Modifier.fillMaxWidth()
+            )
+        } else {
+            ErrorBlock(MarkdownBlock.Error("Failed to render PlantUML: ${block.filename}"))
+        }
+    }
+}
+
+@Composable
+fun ImageBlock(block: MarkdownBlock.Image) {
+    Text(text = "[Image: ${block.altText ?: block.url}]", color = Color.Blue)
+}
+
+@Composable
+fun ErrorBlock(block: MarkdownBlock.Error) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFFFFEBEE), RoundedCornerShape(4.dp))
+            .padding(8.dp)
+    ) {
+        Text(text = block.message, color = Color.Red)
+    }
+}


### PR DESCRIPTION
Implementation of Epic 3: Dynamic Detail View with Markdown Transclusion. This feature allows the plugin to render component details based on a README.md 'script', dynamically injecting code and PlantUML diagrams from the local component cache. The UI is built with Compose Multiplatform and Jewel, following modern 'Islands' UI principles. Key technical highlights include a secure AST-based transclusion resolver and a custom-built syntax highlighter for code blocks.

Fixes #5

---
*PR created automatically by Jules for task [5492624666409960597](https://jules.google.com/task/5492624666409960597) started by @tkpixel*