### PR TITLE
Implement Editor Interaction: Copy Code & Insert at Cursor

### DIFF
--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -11,6 +11,7 @@ import com.example.devfastjavafx.cache.TemplateCache
 import com.example.devfastjavafx.ui.markdown.MarkdownParser
 import com.example.devfastjavafx.ui.markdown.MarkdownRenderer
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.project.Project
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.HorizontalSplitLayout
@@ -19,7 +20,7 @@ import org.jetbrains.jewel.ui.component.rememberSplitLayoutState
 import java.nio.file.Paths
 
 @Composable
-fun DevFastToolWindowContent() {
+fun DevFastToolWindowContent(project: Project) {
     val allFiles = remember { TemplateCache.listCachedTemplates() }
     val components = remember(allFiles) {
         // Group by directory and identify components by presence of manifest.json
@@ -64,7 +65,7 @@ fun DevFastToolWindowContent() {
                     val readmeContent = TemplateCache.loadTemplate(readmePath)
                     if (readmeContent != null) {
                         val blocks = remember(readmeContent) { markdownParser.parse(readmeContent) }
-                        MarkdownRenderer(blocks)
+                        MarkdownRenderer(blocks, project)
                     }
                 } else {
                     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowFactory.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowFactory.kt
@@ -8,7 +8,7 @@ import org.jetbrains.jewel.bridge.addComposeTab
 class DevFastToolWindowFactory : ToolWindowFactory {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         toolWindow.addComposeTab("Templates") {
-            DevFastToolWindowContent()
+            DevFastToolWindowContent(project)
         }
     }
 }

--- a/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownRenderer.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownRenderer.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -32,10 +34,10 @@ import java.awt.datatransfer.StringSelection
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.Project
 
 @Composable
-fun MarkdownRenderer(blocks: List<MarkdownBlock>) {
+fun MarkdownRenderer(blocks: List<MarkdownBlock>, project: Project) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
@@ -45,7 +47,7 @@ fun MarkdownRenderer(blocks: List<MarkdownBlock>) {
             when (block) {
                 is MarkdownBlock.Heading -> HeadingBlock(block)
                 is MarkdownBlock.Text -> TextBlock(block)
-                is MarkdownBlock.Code -> CodeBlock(block)
+                is MarkdownBlock.Code -> CodeBlock(block, project)
                 is MarkdownBlock.PlantUML -> PlantUMLBlock(block)
                 is MarkdownBlock.Image -> ImageBlock(block)
                 is MarkdownBlock.Error -> ErrorBlock(block)
@@ -75,16 +77,20 @@ fun TextBlock(block: MarkdownBlock.Text) {
     Text(text = block.content)
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun CodeBlock(block: MarkdownBlock.Code) {
+fun CodeBlock(block: MarkdownBlock.Code, project: Project) {
     val annotatedContent = remember(block.content, block.language) {
         highlightCode(block.content, block.language)
     }
+    var isHovered by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(Color(0xFF2B2B2B), RoundedCornerShape(4.dp))
+            .onPointerEvent(PointerEventType.Enter) { isHovered = true }
+            .onPointerEvent(PointerEventType.Exit) { isHovered = false }
             .padding(8.dp)
     ) {
         Row(
@@ -92,25 +98,28 @@ fun CodeBlock(block: MarkdownBlock.Code) {
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(text = block.filename, color = Color.Gray, fontSize = 12.sp)
-            Row {
-                ActionButton(onClick = {
-                    CopyPasteManager.getInstance().setContents(StringSelection(block.content))
-                }) {
-                    Text("Copy")
-                }
-                Spacer(modifier = Modifier.width(4.dp))
-                ActionButton(onClick = {
-                    val project = ProjectManager.getInstance().openProjects.firstOrNull() ?: return@ActionButton
-                    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@ActionButton
-                    val document = editor.document
-                    val caretModel = editor.caretModel
-                    val offset = caretModel.offset
-
-                    WriteCommandAction.runWriteCommandAction(project) {
-                        document.insertString(offset, block.content)
+            if (isHovered) {
+                Row {
+                    ActionButton(onClick = {
+                        CopyPasteManager.getInstance().setContents(StringSelection(block.content))
+                    }) {
+                        Text("Copy")
                     }
-                }) {
-                    Text("Insert")
+                    Spacer(modifier = Modifier.width(4.dp))
+                    ActionButton(onClick = {
+                        val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@ActionButton
+                        val document = editor.document
+                        val caretModel = editor.caretModel
+                        val offset = caretModel.offset
+
+                        WriteCommandAction.runWriteCommandAction(project) {
+                            WriteAction.run<Throwable> {
+                                document.insertString(offset, block.content)
+                            }
+                        }
+                    }) {
+                        Text("Insert")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Implemented the "Editor Interaction" feature for the DevFast IntelliJ plugin. This includes:
1. **Hover State UI:** Action buttons (Copy and Insert) now appear only when hovering over a code block in the Markdown detail view.
2. **Project Context:** The `Project` instance is now passed down to the UI components to allow interaction with the active editor.
3. **Copy to Clipboard:** One-click copying of template code using `CopyPasteManager`.
4. **Intelligent Insertion:** One-click insertion of code at the current caret position in the active editor. This is wrapped in a `WriteCommandAction` and `WriteAction` to ensure thread safety and a seamless integration with the IDE's undo history.
5. **Testing:** Verified that the project builds and all existing tests pass.

Fixes #7

---
*PR created automatically by Jules for task [6543895578599482355](https://jules.google.com/task/6543895578599482355) started by @tkpixel*