### PR TITLE
Implement Search & Favorites Management

### DIFF
--- a/src/main/kotlin/com/example/devfastjavafx/api/GitLabModels.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/api/GitLabModels.kt
@@ -24,3 +24,11 @@ data class GitLabFile(
     val commit_id: String,
     val last_commit_id: String
 )
+
+@Serializable
+data class ComponentMetadata(
+    val name: String,
+    val description: String = "",
+    val tags: List<String> = emptyList(),
+    val id: String = ""
+)

--- a/src/main/kotlin/com/example/devfastjavafx/service/FavoritesService.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/service/FavoritesService.kt
@@ -1,0 +1,37 @@
+package com.example.devfastjavafx.service
+
+import com.intellij.openapi.components.*
+
+@Service(Service.Level.APP)
+@State(
+    name = "DevFastFavorites",
+    storages = [Storage("devFastFavorites.xml")]
+)
+class FavoritesService : PersistentStateComponent<FavoritesService.State> {
+
+    class State {
+        var favoriteIds: MutableSet<String> = mutableSetOf()
+    }
+
+    private var myState = State()
+
+    override fun getState(): State = myState
+
+    override fun loadState(state: State) {
+        myState = state
+    }
+
+    fun isFavorite(id: String): Boolean = myState.favoriteIds.contains(id)
+
+    fun toggleFavorite(id: String) {
+        if (myState.favoriteIds.contains(id)) {
+            myState.favoriteIds.remove(id)
+        } else {
+            myState.favoriteIds.add(id)
+        }
+    }
+
+    companion object {
+        fun getInstance(): FavoritesService = service()
+    }
+}

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -2,33 +2,72 @@ package com.example.devfastjavafx.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.devfastjavafx.api.ComponentMetadata
 import com.example.devfastjavafx.cache.TemplateCache
+import com.example.devfastjavafx.service.FavoritesService
 import com.example.devfastjavafx.ui.markdown.MarkdownParser
 import com.example.devfastjavafx.ui.markdown.MarkdownRenderer
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
+import androidx.compose.ui.Alignment
 import org.jetbrains.jewel.ui.Orientation
+import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.HorizontalSplitLayout
+import kotlinx.serialization.json.Json
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextField
 import org.jetbrains.jewel.ui.component.rememberSplitLayoutState
 import java.nio.file.Paths
+
+private val json = Json { ignoreUnknownKeys = true }
 
 @Composable
 fun DevFastToolWindowContent(project: Project) {
     val allFiles = remember { TemplateCache.listCachedTemplates() }
-    val components = remember(allFiles) {
-        // Group by directory and identify components by presence of manifest.json
+    val componentsMetadata = remember(allFiles) {
         allFiles.filter { it.endsWith("manifest.json") }
-            .map { it.substringBeforeLast("/manifest.json").substringAfterLast("/") }
-            .distinct()
+            .mapNotNull { path ->
+                TemplateCache.loadTemplate(path)?.let { content ->
+                    try {
+                        val metadata = json.decodeFromString<ComponentMetadata>(content)
+                        val id = path.substringBeforeLast("/manifest.json").substringAfterLast("/")
+                        metadata.copy(id = id)
+                    } catch (e: Exception) {
+                        null
+                    }
+                }
+            }
     }
     var selectedComponent by remember { mutableStateOf<String?>(null) }
+    var searchQuery by remember { mutableStateOf("") }
+
+    val favoritesService = remember { FavoritesService.getInstance() }
+    var favoritesUpdated by remember { mutableLongStateOf(0L) }
+
+    val filteredComponents = remember(componentsMetadata, searchQuery, favoritesUpdated) {
+        val sorted = componentsMetadata.sortedWith(
+            compareByDescending<ComponentMetadata> { favoritesService.isFavorite(it.id) }
+                .thenBy { it.name }
+        )
+
+        if (searchQuery.isBlank()) {
+            sorted
+        } else {
+            sorted.filter { component ->
+                component.name.contains(searchQuery, ignoreCase = true) ||
+                        component.tags.any { it.contains(searchQuery, ignoreCase = true) }
+            }
+        }
+    }
+
     val splitLayoutState = rememberSplitLayoutState(0.3f)
 
     HorizontalSplitLayout(
@@ -40,16 +79,34 @@ fun DevFastToolWindowContent(project: Project) {
                     text = "JavaFX Components",
                     modifier = Modifier.padding(8.dp)
                 )
+                TextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    modifier = Modifier.fillMaxWidth().padding(8.dp),
+                    placeholder = { Text("Search components...") }
+                )
                 Divider(orientation = Orientation.Horizontal)
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(components) { component ->
-                        Box(
+                    items(filteredComponents, key = { it.id }) { component ->
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { selectedComponent = component }
-                                .padding(8.dp)
+                                .clickable { selectedComponent = component.id }
+                                .padding(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
                         ) {
-                            Text(text = component)
+                            Text(text = component.name, modifier = Modifier.weight(1f))
+
+                            val isFavorite = favoritesService.isFavorite(component.id)
+                            ActionButton(
+                                onClick = {
+                                    favoritesService.toggleFavorite(component.id)
+                                    favoritesUpdated++
+                                }
+                            ) {
+                                Text(if (isFavorite) "★" else "☆")
+                            }
                         }
                     }
                 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.example.devfastjavafx.service.TemplateLoaderService"/>
+        <applicationService serviceImplementation="com.example.devfastjavafx.service.FavoritesService"/>
         <postStartupActivity implementation="com.example.devfastjavafx.activity.TemplateStartupActivity"/>
         <toolWindow id="DevFastJavaFx" anchor="right" factoryClass="com.example.devfastjavafx.ui.DevFastToolWindowFactory" />
     </extensions>

--- a/src/test/kotlin/com/example/devfastjavafx/api/SearchLogicTest.kt
+++ b/src/test/kotlin/com/example/devfastjavafx/api/SearchLogicTest.kt
@@ -1,0 +1,43 @@
+package com.example.devfastjavafx.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SearchLogicTest {
+
+    private val components = listOf(
+        ComponentMetadata(name = "Button", tags = listOf("ui", "basic"), id = "btn"),
+        ComponentMetadata(name = "Table", tags = listOf("ui", "data"), id = "tbl"),
+        ComponentMetadata(name = "Network Client", tags = listOf("network", "api"), id = "net")
+    )
+
+    @Test
+    fun `test search by name`() {
+        val query = "Button"
+        val filtered = components.filter { it.name.contains(query, ignoreCase = true) }
+        assertEquals(1, filtered.size)
+        assertEquals("btn", filtered[0].id)
+    }
+
+    @Test
+    fun `test search by tag`() {
+        val query = "network"
+        val filtered = components.filter { component ->
+            component.name.contains(query, ignoreCase = true) ||
+                    component.tags.any { it.contains(query, ignoreCase = true) }
+        }
+        assertEquals(1, filtered.size)
+        assertEquals("net", filtered[0].id)
+    }
+
+    @Test
+    fun `test fuzzy search case insensitive`() {
+        val query = "UI"
+        val filtered = components.filter { component ->
+            component.name.contains(query, ignoreCase = true) ||
+                    component.tags.any { it.contains(query, ignoreCase = true) }
+        }
+        assertEquals(2, filtered.size)
+    }
+}


### PR DESCRIPTION
This PR implements Epic 4: Search & Favorites Management.

Key changes:
1. **Favorites Management**: A new `FavoritesService` allows users to mark templates as favorites. This state is persisted in `devFastFavorites.xml` using IntelliJ's `PersistentStateComponent`.
2. **Search Logic**: A search bar was added to the tool window. It supports substring matching against component names and tags.
3. **Component Metadata**: The plugin now parses `manifest.json` files to extract richer metadata (name, tags) instead of just using directory names.
4. **UI Improvements**: Favorites are pinned to the top of the component list and marked with a star icon. The list updates reactively when favorites are toggled or search terms are entered.
5. **Testing**: Added `SearchLogicTest` to verify the search and filtering behavior.

Verified compilation and ran unit tests.

Fixes #8

---
*PR created automatically by Jules for task [11808996043917997950](https://jules.google.com/task/11808996043917997950) started by @tkpixel*