### PR TITLE
Configurable Settings Menu for GitLab Connection (URL & PAT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,14 @@ build/
 
 # IntelliJ Platform
 .intellijPlatform/
+.gemini/
+gha-creds-*.json
+
+.gemini/settings.json
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:2.3.7")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.7")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     implementation("com.vladsch.flexmark:flexmark-all:0.64.8")
     implementation("net.sourceforge.plantuml:plantuml:1.2023.12")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     implementation("com.vladsch.flexmark:flexmark-all:0.64.8")
-    implementation("net.sourceforge.plantuml:plantuml:1.2023.12")
+    implementation("net.sourceforge.plantuml:plantuml:1.2025.2")
 
     implementation("org.jetbrains.jewel:jewel-ide-laf-bridge-243:0.27.0")
     api(compose.desktop.currentOs) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.example.devfastjavafx"
-version = "0.1.0-alpha"
+version = "0.2.0-beta"
 
 repositories {
     google()
@@ -47,7 +47,7 @@ intellijPlatform {
     pluginConfiguration {
         id = "com.example.devfastjavafx"
         name = "devFastJavaFx"
-        version = "0.1.0-alpha"
+        version = "0.2.0-beta"
 
         vendor {
             name = "Example"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 pluginVersion = 0.1.0-alpha
 pluginGroup = com.example.devfastjavafx
+org.gradle.java.home=C:/Users/TobiasToKoehler/.jdks/azul-21.0.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/com/example/devfastjavafx/api/GitLabClient.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/api/GitLabClient.kt
@@ -3,6 +3,7 @@ package com.example.devfastjavafx.api
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.serialization.kotlinx.json.*
@@ -20,6 +21,11 @@ class GitLabClient(
                 ignoreUnknownKeys = true
                 coerceInputValues = true
             })
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 10000 // 10 seconds
+            connectTimeoutMillis = 5000  // 5 seconds
+            socketTimeoutMillis = 10000
         }
     }
 

--- a/src/main/kotlin/com/example/devfastjavafx/api/GitLabClient.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/api/GitLabClient.kt
@@ -31,6 +31,12 @@ class GitLabClient(
         }.body()
     }
 
+    suspend fun getProject(projectId: String): GitLabProject {
+        return client.get("$baseUrl/api/v4/projects/$projectId") {
+            privateToken?.let { header("PRIVATE-TOKEN", it) }
+        }.body()
+    }
+
     suspend fun getFileContent(projectId: String, filePath: String, ref: String = "main"): GitLabFile {
         val encodedFilePath = URLEncoder.encode(filePath, StandardCharsets.UTF_8.toString())
         return client.get("$baseUrl/api/v4/projects/$projectId/repository/files/$encodedFilePath") {

--- a/src/main/kotlin/com/example/devfastjavafx/api/GitLabClient.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/api/GitLabClient.kt
@@ -43,7 +43,7 @@ class GitLabClient(
         }.body()
     }
 
-    suspend fun getFileContent(projectId: String, filePath: String, ref: String = "main"): GitLabFile {
+    suspend fun getFileContent(projectId: String, filePath: String, ref: String = "master"): GitLabFile {
         val encodedFilePath = URLEncoder.encode(filePath, StandardCharsets.UTF_8.toString())
         return client.get("$baseUrl/api/v4/projects/$projectId/repository/files/$encodedFilePath") {
             parameter("ref", ref)

--- a/src/main/kotlin/com/example/devfastjavafx/api/GitLabModels.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/api/GitLabModels.kt
@@ -4,33 +4,33 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GitLabTreeItem(
-    val id: String,
-    val name: String,
-    val type: String,
-    val path: String,
-    val mode: String
+    val id: String = "",
+    val name: String = "",
+    val type: String = "",
+    val path: String = "",
+    val mode: String = ""
 )
 
 @Serializable
 data class GitLabProject(
-    val id: String,
-    val name: String,
+    val id: Long = 0L,
+    val name: String = "",
     val description: String? = null,
-    val web_url: String
+    val web_url: String = ""
 )
 
 @Serializable
 data class GitLabFile(
-    val file_name: String,
-    val file_path: String,
-    val size: Int,
-    val encoding: String,
-    val content: String,
-    val content_sha256: String,
-    val ref: String,
-    val blob_id: String,
-    val commit_id: String,
-    val last_commit_id: String
+    val file_name: String = "",
+    val file_path: String = "",
+    val size: Int = 0,
+    val encoding: String = "",
+    val content: String = "",
+    val content_sha256: String = "",
+    val ref: String = "",
+    val blob_id: String = "",
+    val commit_id: String = "",
+    val last_commit_id: String = ""
 )
 
 @Serializable

--- a/src/main/kotlin/com/example/devfastjavafx/api/GitLabModels.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/api/GitLabModels.kt
@@ -12,6 +12,14 @@ data class GitLabTreeItem(
 )
 
 @Serializable
+data class GitLabProject(
+    val id: String,
+    val name: String,
+    val description: String? = null,
+    val web_url: String
+)
+
+@Serializable
 data class GitLabFile(
     val file_name: String,
     val file_path: String,

--- a/src/main/kotlin/com/example/devfastjavafx/service/PlantUmlRenderingService.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/service/PlantUmlRenderingService.kt
@@ -4,7 +4,10 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.sourceforge.plantuml.FileFormat
 import net.sourceforge.plantuml.FileFormatOption
@@ -19,6 +22,9 @@ import java.util.LinkedHashMap
 @Service(Service.Level.APP)
 class PlantUmlRenderingService {
 
+    private val LOG = logger<PlantUmlRenderingService>()
+    private val renderMutex = Mutex()
+
     private val cacheLimit = 20
     private val cache = Collections.synchronizedMap(object : LinkedHashMap<String, ImageBitmap>(cacheLimit, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ImageBitmap>?): Boolean {
@@ -30,46 +36,62 @@ class PlantUmlRenderingService {
         val hash = hashString(content)
         cache[hash]?.let { return@withContext it }
 
-        try {
-            // Configure PlantUML to use Smetana and set size limits
-            System.setProperty("PLANTUML_LIMIT_SIZE", "8192")
+        renderMutex.withLock {
+            // Double-check after acquiring lock (another coroutine may have rendered it already)
+            cache[hash]?.let { return@withLock it }
 
-            // To ensure Smetana is used, we explicitly prepend !pragma useSmetana
-            val plantUmlContent = if (content.contains("@startuml")) {
-                if (content.contains("!pragma useSmetana")) {
-                    content
-                } else {
-                    content.replaceFirst("@startuml", "@startuml\n!pragma useSmetana")
+            try {
+                System.setProperty("PLANTUML_LIMIT_SIZE", "8192")
+
+                val reader = SourceStringReader(fixComponentNotes(content))
+                val os = ByteArrayOutputStream()
+                val result = reader.outputImage(os, FileFormatOption(FileFormat.PNG))
+
+                LOG.debug("PlantUML result description: ${result?.description}")
+
+                val bytes = os.toByteArray()
+                // Check bytes first – PlantUML may return "(Error)" in description even when the
+                // image renders successfully (e.g. component names containing dots like "LoginView.java").
+                if (bytes.isEmpty()) {
+                    LOG.warn("PlantUML render produced empty output. Description: ${result?.description}")
+                    return@withLock null
                 }
-            } else {
-                "@startuml\n!pragma useSmetana\n$content\n@enduml"
+
+                val skiaImage = Image.makeFromEncoded(bytes)
+                val bitmap = Bitmap.makeFromImage(skiaImage)
+                val imageBitmap = bitmap.asComposeImageBitmap()
+
+                cache[hash] = imageBitmap
+                imageBitmap
+            } catch (e: Exception) {
+                LOG.error("PlantUML rendering exception", e)
+                null
             }
-
-            val reader = SourceStringReader(plantUmlContent)
-            val os = ByteArrayOutputStream()
-
-            val result = reader.outputImage(os, FileFormatOption(FileFormat.PNG))
-            if (result == null || result.description == "(Error)") {
-                return@withContext null
-            }
-
-            val bytes = os.toByteArray()
-            if (bytes.isEmpty()) return@withContext null
-
-            val skiaImage = Image.makeFromEncoded(bytes)
-            val bitmap = Bitmap.makeFromImage(skiaImage)
-            val imageBitmap = bitmap.asComposeImageBitmap()
-
-            cache[hash] = imageBitmap
-            imageBitmap
-        } catch (e: Exception) {
-            null
         }
     }
 
     private fun hashString(input: String): String {
         val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray())
         return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Rewrites "note right/left/top/bottom of <alias>" blocks to the standalone
+     * "note as N\n...\nend note\nN .. <alias>" syntax, which avoids the PlantUML
+     * "element already defined" bug in Component Diagrams.
+     */
+    private fun fixComponentNotes(content: String): String {
+        val notePattern = Regex(
+            """note\s+(right|left|top|bottom)\s+of\s+(\w+)\s*\n(.*?)\nend note""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
+        )
+        var counter = 0
+        return notePattern.replace(content) { match ->
+            val alias = match.groupValues[2]
+            val body = match.groupValues[3]
+            val noteName = "N_${alias}_${counter++}"
+            "note as $noteName\n$body\nend note\n$noteName .. $alias"
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/example/devfastjavafx/service/TemplateLoaderService.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/service/TemplateLoaderService.kt
@@ -5,6 +5,7 @@ import com.example.devfastjavafx.cache.TemplateCache
 import com.example.devfastjavafx.credentials.GitLabCredentialsManager
 import com.example.devfastjavafx.settings.GitLabSettingsState
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,10 +15,9 @@ import java.util.*
 @Service(Service.Level.APP)
 class TemplateLoaderService(private val scope: CoroutineScope) {
     private val LOG = logger<TemplateLoaderService>()
-
     private val TEMPLATE_PATH = "templates"
 
-    fun loadTemplates() {
+    fun loadTemplates(onComplete: (() -> Unit)? = null) {
         scope.launch(Dispatchers.IO) {
             try {
                 val settings = GitLabSettingsState.getInstance().state
@@ -50,7 +50,13 @@ class TemplateLoaderService(private val scope: CoroutineScope) {
                 }
             } catch (e: Exception) {
                 LOG.error("Failed to load templates from GitLab", e)
+            } finally {
+                onComplete?.invoke()
             }
         }
+    }
+
+    companion object {
+        fun getInstance(): TemplateLoaderService = service()
     }
 }

--- a/src/main/kotlin/com/example/devfastjavafx/service/TemplateLoaderService.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/service/TemplateLoaderService.kt
@@ -3,6 +3,7 @@ package com.example.devfastjavafx.service
 import com.example.devfastjavafx.api.GitLabClient
 import com.example.devfastjavafx.cache.TemplateCache
 import com.example.devfastjavafx.credentials.GitLabCredentialsManager
+import com.example.devfastjavafx.settings.GitLabSettingsState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import kotlinx.coroutines.CoroutineScope
@@ -14,26 +15,27 @@ import java.util.*
 class TemplateLoaderService(private val scope: CoroutineScope) {
     private val LOG = logger<TemplateLoaderService>()
 
-    // These should ideally come from configuration
-    private val GITLAB_BASE_URL = "https://gitlab.example.com"
-    private val PROJECT_ID = "12345"
     private val TEMPLATE_PATH = "templates"
 
     fun loadTemplates() {
         scope.launch(Dispatchers.IO) {
             try {
+                val settings = GitLabSettingsState.getInstance().state
+                val baseUrl = settings.gitlabUrl
+                val projectId = settings.projectId
                 val token = GitLabCredentialsManager.getToken()
-                if (token == null) {
-                    LOG.warn("GitLab token not found. Skipping template loading.")
+
+                if (baseUrl.isEmpty() || projectId.isEmpty() || token.isNullOrEmpty()) {
+                    LOG.warn("GitLab settings or token not configured. Skipping template loading.")
                     return@launch
                 }
 
-                val client = GitLabClient(GITLAB_BASE_URL, token)
+                val client = GitLabClient(baseUrl, token)
                 try {
-                    val tree = client.getRepositoryTree(PROJECT_ID, TEMPLATE_PATH)
+                    val tree = client.getRepositoryTree(projectId, TEMPLATE_PATH)
                     for (item in tree) {
                         if (item.type == "blob") {
-                            val file = client.getFileContent(PROJECT_ID, item.path)
+                            val file = client.getFileContent(projectId, item.path)
                             val content = if (file.encoding == "base64") {
                                 String(Base64.getMimeDecoder().decode(file.content))
                             } else {

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
@@ -2,6 +2,7 @@ package com.example.devfastjavafx.settings
 
 import com.example.devfastjavafx.api.GitLabClient
 import com.intellij.icons.AllIcons
+import com.intellij.ui.AnimatedIcon
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
@@ -42,34 +43,33 @@ class GitLabSettingsComponent(private val scope: CoroutineScope) {
         val token = token
 
         feedbackLabel.text = "Testing..."
-        feedbackLabel.icon = AllIcons.Process.Step_1
+        feedbackLabel.icon = AnimatedIcon.Default.INSTANCE
+        feedbackLabel.isVisible = true
 
         scope.launch {
-            val result = withContext(Dispatchers.IO) {
+            val result = try {
+                val client = withContext(Dispatchers.IO) { GitLabClient(url, token) }
                 try {
-                val client = GitLabClient(url, token)
-                try {
-                    client.getProject(id)
+                    withContext(Dispatchers.IO) { client.getProject(id) }
                     Result.success("Connection successful")
-                    } finally {
-                        client.close()
-                    }
-                } catch (e: ClientRequestException) {
-                    if (e.response.status.value == 401) {
-                        Result.failure(Exception("Authentication failed: Invalid Token (HTTP 401)"))
-                    } else if (e.response.status.value == 404) {
-                        Result.failure(Exception("Connection failed: Repository not found (HTTP 404)"))
-                    } else {
-                        Result.failure(Exception("Connection failed: ${e.message ?: "Status ${e.response.status}"}"))
-                    }
-                } catch (e: Exception) {
-                    Result.failure(Exception("Connection failed: ${e.message ?: "Unknown error"}"))
+                } finally {
+                    withContext(Dispatchers.IO) { client.close() }
                 }
+            } catch (e: ClientRequestException) {
+                if (e.response.status.value == 401) {
+                    Result.failure(Exception("Authentication failed: Invalid Token (HTTP 401)"))
+                } else if (e.response.status.value == 404) {
+                    Result.failure(Exception("Connection failed: Repository not found (HTTP 404)"))
+                } else {
+                    Result.failure(Exception("Connection failed: ${e.message ?: "Status ${e.response.status}"}"))
+                }
+            } catch (e: Exception) {
+                Result.failure(Exception("Connection failed: ${e.message ?: "Unknown error"}"))
             }
 
             result.onSuccess { message ->
-                    feedbackLabel.text = message
-                    feedbackLabel.icon = AllIcons.General.InspectionsOK
+                feedbackLabel.text = message
+                feedbackLabel.icon = AllIcons.General.InspectionsOK
             }.onFailure { error ->
                 feedbackLabel.text = error.message ?: "Unknown error"
                 feedbackLabel.icon = AllIcons.General.Error

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
@@ -1,14 +1,20 @@
 package com.example.devfastjavafx.settings
 
+import com.example.devfastjavafx.api.GitLabClient
+import com.intellij.icons.AllIcons
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.panel
+import io.ktor.client.plugins.*
+import kotlinx.coroutines.*
 import javax.swing.JPanel
 
-class GitLabSettingsComponent {
+class GitLabSettingsComponent(private val scope: CoroutineScope) {
     private val gitlabUrlField = JBTextField()
     private val projectIdField = JBTextField()
     private val tokenField = JBPasswordField()
+    private val feedbackLabel = JBLabel()
 
     val panel: JPanel = panel {
         group("GitLab Connection") {
@@ -20,6 +26,53 @@ class GitLabSettingsComponent {
             }
             row("Personal Access Token:") {
                 cell(tokenField).align(com.intellij.ui.dsl.builder.AlignX.FILL)
+            }
+            row {
+                button("Test Connection") {
+                    testConnection()
+                }
+                cell(feedbackLabel)
+            }
+        }
+    }
+
+    private fun testConnection() {
+        val url = gitlabUrl
+        val id = projectId
+        val token = token
+
+        feedbackLabel.text = "Testing..."
+        feedbackLabel.icon = AllIcons.Process.Step_1
+
+        scope.launch {
+            val result = withContext(Dispatchers.IO) {
+                try {
+                val client = GitLabClient(url, token)
+                try {
+                    client.getProject(id)
+                    Result.success("Connection successful")
+                    } finally {
+                        client.close()
+                    }
+                } catch (e: ClientRequestException) {
+                    if (e.response.status.value == 401) {
+                        Result.failure(Exception("Authentication failed: Invalid Token (HTTP 401)"))
+                    } else if (e.response.status.value == 404) {
+                        Result.failure(Exception("Connection failed: Repository not found (HTTP 404)"))
+                    } else {
+                        Result.failure(Exception("Connection failed: ${e.message ?: "Status ${e.response.status}"}"))
+                    }
+                } catch (e: Exception) {
+                    Result.failure(Exception("Connection failed: ${e.message ?: "Unknown error"}"))
+                }
+            }
+
+            result.onSuccess { message ->
+                    feedbackLabel.text = message
+                    feedbackLabel.icon = AllIcons.General.InspectionsOK
+            }.onFailure { error ->
+                feedbackLabel.text = error.message ?: "Unknown error"
+                feedbackLabel.icon = AllIcons.General.Error
             }
         }
     }

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
@@ -1,0 +1,44 @@
+package com.example.devfastjavafx.settings
+
+import com.intellij.ui.components.JBPasswordField
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.panel
+import javax.swing.JPanel
+
+class GitLabSettingsComponent {
+    private val gitlabUrlField = JBTextField()
+    private val projectIdField = JBTextField()
+    private val tokenField = JBPasswordField()
+
+    val panel: JPanel = panel {
+        group("GitLab Connection") {
+            row("GitLab URL:") {
+                cell(gitlabUrlField).align(com.intellij.ui.dsl.builder.AlignX.FILL)
+            }
+            row("Project ID:") {
+                cell(projectIdField).align(com.intellij.ui.dsl.builder.AlignX.FILL)
+            }
+            row("Personal Access Token:") {
+                cell(tokenField).align(com.intellij.ui.dsl.builder.AlignX.FILL)
+            }
+        }
+    }
+
+    var gitlabUrl: String
+        get() = gitlabUrlField.text
+        set(value) {
+            gitlabUrlField.text = value
+        }
+
+    var projectId: String
+        get() = projectIdField.text
+        set(value) {
+            projectIdField.text = value
+        }
+
+    var token: String
+        get() = String(tokenField.password)
+        set(value) {
+            tokenField.text = value
+        }
+}

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
@@ -2,7 +2,7 @@ package com.example.devfastjavafx.settings
 
 import com.example.devfastjavafx.api.GitLabClient
 import com.intellij.icons.AllIcons
-import com.intellij.ui.AnimatedIcon
+import com.intellij.util.ui.AsyncProcessIcon
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
@@ -16,6 +16,7 @@ class GitLabSettingsComponent(private val scope: CoroutineScope) {
     private val projectIdField = JBTextField()
     private val tokenField = JBPasswordField()
     private val feedbackLabel = JBLabel()
+    private val loadingIcon = AsyncProcessIcon("GitLabTestConnection").apply { isVisible = false }
 
     val panel: JPanel = panel {
         group("GitLab Connection") {
@@ -32,6 +33,7 @@ class GitLabSettingsComponent(private val scope: CoroutineScope) {
                 button("Test Connection") {
                     testConnection()
                 }
+                cell(loadingIcon)
                 cell(feedbackLabel)
             }
         }
@@ -43,8 +45,10 @@ class GitLabSettingsComponent(private val scope: CoroutineScope) {
         val token = token
 
         feedbackLabel.text = "Testing..."
-        feedbackLabel.icon = AnimatedIcon.Default.INSTANCE
+        feedbackLabel.icon = null
         feedbackLabel.isVisible = true
+        loadingIcon.isVisible = true
+        loadingIcon.resume()
 
         scope.launch {
             val result = try {
@@ -66,6 +70,9 @@ class GitLabSettingsComponent(private val scope: CoroutineScope) {
             } catch (e: Exception) {
                 Result.failure(Exception("Connection failed: ${e.message ?: "Unknown error"}"))
             }
+
+            loadingIcon.suspend()
+            loadingIcon.isVisible = false
 
             result.onSuccess { message ->
                 feedbackLabel.text = message

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsComponent.kt
@@ -51,35 +51,37 @@ class GitLabSettingsComponent(private val scope: CoroutineScope) {
         loadingIcon.resume()
 
         scope.launch {
-            val result = try {
-                val client = withContext(Dispatchers.IO) { GitLabClient(url, token) }
-                try {
-                    withContext(Dispatchers.IO) { client.getProject(id) }
-                    Result.success("Connection successful")
-                } finally {
-                    withContext(Dispatchers.IO) { client.close() }
+            try {
+                val result = try {
+                    val client = withContext(Dispatchers.IO) { GitLabClient(url, token) }
+                    try {
+                        withContext(Dispatchers.IO) { client.getProject(id) }
+                        Result.success("Connection successful")
+                    } finally {
+                        withContext(Dispatchers.IO) { client.close() }
+                    }
+                } catch (e: ClientRequestException) {
+                    if (e.response.status.value == 401) {
+                        Result.failure(Exception("Authentication failed: Invalid Token (HTTP 401)"))
+                    } else if (e.response.status.value == 404) {
+                        Result.failure(Exception("Connection failed: Repository not found (HTTP 404)"))
+                    } else {
+                        Result.failure(Exception("Connection failed: ${e.message ?: "Status ${e.response.status}"}"))
+                    }
+                } catch (e: Exception) {
+                    Result.failure(Exception("Connection failed: ${e.message ?: "Unknown error"}"))
                 }
-            } catch (e: ClientRequestException) {
-                if (e.response.status.value == 401) {
-                    Result.failure(Exception("Authentication failed: Invalid Token (HTTP 401)"))
-                } else if (e.response.status.value == 404) {
-                    Result.failure(Exception("Connection failed: Repository not found (HTTP 404)"))
-                } else {
-                    Result.failure(Exception("Connection failed: ${e.message ?: "Status ${e.response.status}"}"))
+
+                result.onSuccess { message ->
+                    feedbackLabel.text = message
+                    feedbackLabel.icon = AllIcons.General.InspectionsOK
+                }.onFailure { error ->
+                    feedbackLabel.text = error.message ?: "Unknown error"
+                    feedbackLabel.icon = AllIcons.General.Error
                 }
-            } catch (e: Exception) {
-                Result.failure(Exception("Connection failed: ${e.message ?: "Unknown error"}"))
-            }
-
-            loadingIcon.suspend()
-            loadingIcon.isVisible = false
-
-            result.onSuccess { message ->
-                feedbackLabel.text = message
-                feedbackLabel.icon = AllIcons.General.InspectionsOK
-            }.onFailure { error ->
-                feedbackLabel.text = error.message ?: "Unknown error"
-                feedbackLabel.icon = AllIcons.General.Error
+            } finally {
+                loadingIcon.suspend()
+                loadingIcon.isVisible = false
             }
         }
     }

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
@@ -2,7 +2,7 @@ package com.example.devfastjavafx.settings
 
 import com.example.devfastjavafx.credentials.GitLabCredentialsManager
 import com.intellij.openapi.options.Configurable
-import com.intellij.openapi.util.Disposer
+import com.intellij.util.SlowOperations
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -13,6 +13,7 @@ import javax.swing.JComponent
 class GitLabSettingsConfigurable : Configurable {
     private var mySettingsComponent: GitLabSettingsComponent? = null
     private var scope: CoroutineScope? = null
+    private var originalToken: String = ""
 
     @Nls(capitalization = Nls.Capitalization.Title)
     override fun getDisplayName(): String {
@@ -29,21 +30,29 @@ class GitLabSettingsConfigurable : Configurable {
         val state = GitLabSettingsState.getInstance().state
         return mySettingsComponent!!.gitlabUrl != state.gitlabUrl ||
                 mySettingsComponent!!.projectId != state.projectId ||
-                mySettingsComponent!!.token != (GitLabCredentialsManager.getToken() ?: "")
+                mySettingsComponent!!.token != originalToken
     }
 
     override fun apply() {
         val state = GitLabSettingsState.getInstance().state
         state.gitlabUrl = mySettingsComponent!!.gitlabUrl
         state.projectId = mySettingsComponent!!.projectId
-        GitLabCredentialsManager.saveToken(mySettingsComponent!!.token)
+        val newToken = mySettingsComponent!!.token
+        SlowOperations.allowSlowOperations("devFastJavaFx.saveToken").use {
+            GitLabCredentialsManager.saveToken(newToken)
+        }
+        originalToken = newToken
     }
 
     override fun reset() {
         val state = GitLabSettingsState.getInstance().state
         mySettingsComponent!!.gitlabUrl = state.gitlabUrl
         mySettingsComponent!!.projectId = state.projectId
-        mySettingsComponent!!.token = GitLabCredentialsManager.getToken() ?: ""
+        val token = SlowOperations.allowSlowOperations("devFastJavaFx.getToken").use {
+            GitLabCredentialsManager.getToken()
+        } ?: ""
+        originalToken = token
+        mySettingsComponent!!.token = token
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
@@ -1,0 +1,45 @@
+package com.example.devfastjavafx.settings
+
+import com.example.devfastjavafx.credentials.GitLabCredentialsManager
+import com.intellij.openapi.options.Configurable
+import org.jetbrains.annotations.Nls
+import javax.swing.JComponent
+
+class GitLabSettingsConfigurable : Configurable {
+    private var mySettingsComponent: GitLabSettingsComponent? = null
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    override fun getDisplayName(): String {
+        return "DevFast GitLab Settings"
+    }
+
+    override fun createComponent(): JComponent? {
+        mySettingsComponent = GitLabSettingsComponent()
+        return mySettingsComponent!!.panel
+    }
+
+    override fun isModified(): Boolean {
+        val state = GitLabSettingsState.getInstance().state
+        return mySettingsComponent!!.gitlabUrl != state.gitlabUrl ||
+                mySettingsComponent!!.projectId != state.projectId ||
+                mySettingsComponent!!.token != (GitLabCredentialsManager.getToken() ?: "")
+    }
+
+    override fun apply() {
+        val state = GitLabSettingsState.getInstance().state
+        state.gitlabUrl = mySettingsComponent!!.gitlabUrl
+        state.projectId = mySettingsComponent!!.projectId
+        GitLabCredentialsManager.saveToken(mySettingsComponent!!.token)
+    }
+
+    override fun reset() {
+        val state = GitLabSettingsState.getInstance().state
+        mySettingsComponent!!.gitlabUrl = state.gitlabUrl
+        mySettingsComponent!!.projectId = state.projectId
+        mySettingsComponent!!.token = GitLabCredentialsManager.getToken() ?: ""
+    }
+
+    override fun disposeUIResources() {
+        mySettingsComponent = null
+    }
+}

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
@@ -2,11 +2,12 @@ package com.example.devfastjavafx.settings
 
 import com.example.devfastjavafx.credentials.GitLabCredentialsManager
 import com.intellij.openapi.options.Configurable
-import com.intellij.util.SlowOperations
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.Nls
 import javax.swing.JComponent
 
@@ -38,23 +39,25 @@ class GitLabSettingsConfigurable : Configurable {
         state.gitlabUrl = mySettingsComponent!!.gitlabUrl
         state.projectId = mySettingsComponent!!.projectId
         val newToken = mySettingsComponent!!.token
-        @Suppress("UnstableApiUsage")
-        SlowOperations.startSection("devFastJavaFx.saveToken").use {
-            GitLabCredentialsManager.saveToken(newToken)
-        }
         originalToken = newToken
+        scope!!.launch {
+            withContext(Dispatchers.IO) {
+                GitLabCredentialsManager.saveToken(newToken)
+            }
+        }
     }
 
     override fun reset() {
         val state = GitLabSettingsState.getInstance().state
         mySettingsComponent!!.gitlabUrl = state.gitlabUrl
         mySettingsComponent!!.projectId = state.projectId
-        @Suppress("UnstableApiUsage")
-        val token = SlowOperations.startSection("devFastJavaFx.getToken").use {
-            GitLabCredentialsManager.getToken()
-        } ?: ""
-        originalToken = token
-        mySettingsComponent!!.token = token
+        scope!!.launch {
+            val token = withContext(Dispatchers.IO) {
+                GitLabCredentialsManager.getToken()
+            } ?: ""
+            originalToken = token
+            mySettingsComponent?.token = token
+        }
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
@@ -2,11 +2,17 @@ package com.example.devfastjavafx.settings
 
 import com.example.devfastjavafx.credentials.GitLabCredentialsManager
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.util.Disposer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import org.jetbrains.annotations.Nls
 import javax.swing.JComponent
 
 class GitLabSettingsConfigurable : Configurable {
     private var mySettingsComponent: GitLabSettingsComponent? = null
+    private var scope: CoroutineScope? = null
 
     @Nls(capitalization = Nls.Capitalization.Title)
     override fun getDisplayName(): String {
@@ -14,7 +20,8 @@ class GitLabSettingsConfigurable : Configurable {
     }
 
     override fun createComponent(): JComponent? {
-        mySettingsComponent = GitLabSettingsComponent()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        mySettingsComponent = GitLabSettingsComponent(scope!!)
         return mySettingsComponent!!.panel
     }
 
@@ -41,5 +48,7 @@ class GitLabSettingsConfigurable : Configurable {
 
     override fun disposeUIResources() {
         mySettingsComponent = null
+        scope?.cancel()
+        scope = null
     }
 }

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsConfigurable.kt
@@ -38,7 +38,8 @@ class GitLabSettingsConfigurable : Configurable {
         state.gitlabUrl = mySettingsComponent!!.gitlabUrl
         state.projectId = mySettingsComponent!!.projectId
         val newToken = mySettingsComponent!!.token
-        SlowOperations.allowSlowOperations("devFastJavaFx.saveToken").use {
+        @Suppress("UnstableApiUsage")
+        SlowOperations.startSection("devFastJavaFx.saveToken").use {
             GitLabCredentialsManager.saveToken(newToken)
         }
         originalToken = newToken
@@ -48,7 +49,8 @@ class GitLabSettingsConfigurable : Configurable {
         val state = GitLabSettingsState.getInstance().state
         mySettingsComponent!!.gitlabUrl = state.gitlabUrl
         mySettingsComponent!!.projectId = state.projectId
-        val token = SlowOperations.allowSlowOperations("devFastJavaFx.getToken").use {
+        @Suppress("UnstableApiUsage")
+        val token = SlowOperations.startSection("devFastJavaFx.getToken").use {
             GitLabCredentialsManager.getToken()
         } ?: ""
         originalToken = token

--- a/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsState.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/settings/GitLabSettingsState.kt
@@ -1,0 +1,28 @@
+package com.example.devfastjavafx.settings
+
+import com.intellij.openapi.components.*
+
+@Service(Service.Level.APP)
+@State(
+    name = "com.example.devfastjavafx.settings.GitLabSettingsState",
+    storages = [Storage("devFastGitLabSettings.xml")]
+)
+class GitLabSettingsState : PersistentStateComponent<GitLabSettingsState.State> {
+
+    class State {
+        var gitlabUrl: String = "https://gitlab.com"
+        var projectId: String = ""
+    }
+
+    private var myState = State()
+
+    override fun getState(): State = myState
+
+    override fun loadState(state: State) {
+        myState = state
+    }
+
+    companion object {
+        fun getInstance(): GitLabSettingsState = service()
+    }
+}

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import com.example.devfastjavafx.api.ComponentMetadata
 import com.example.devfastjavafx.cache.TemplateCache
 import com.example.devfastjavafx.service.FavoritesService
+import com.example.devfastjavafx.service.TemplateLoaderService
 import com.example.devfastjavafx.ui.markdown.MarkdownParser
 import com.example.devfastjavafx.ui.markdown.MarkdownRenderer
 import com.intellij.openapi.application.PathManager
@@ -19,6 +20,7 @@ import com.intellij.openapi.project.Project
 import androidx.compose.ui.Alignment
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.ActionButton
+import org.jetbrains.jewel.ui.component.CircularProgressIndicator
 import org.jetbrains.jewel.ui.component.Divider
 import org.jetbrains.jewel.ui.component.HorizontalSplitLayout
 import kotlinx.serialization.json.Json
@@ -47,14 +49,18 @@ sealed class TemplateTreeItem {
 
 @Composable
 fun DevFastToolWindowContent(project: Project) {
-    val allFiles = remember { TemplateCache.listCachedTemplates() }
+    var refreshTick by remember { mutableLongStateOf(0L) }
+    var isRefreshing by remember { mutableStateOf(false) }
+
+    val allFiles = remember(refreshTick) { TemplateCache.listCachedTemplates() }
     val componentsMetadata = remember(allFiles) {
-        allFiles.filter { it.endsWith("manifest.json") }
+        allFiles.filter { it.endsWith("manifest.json") || it.endsWith("manifest.json".replace("/", "\\")) }
             .mapNotNull { path ->
                 TemplateCache.loadTemplate(path)?.let { content ->
                     try {
                         val metadata = json.decodeFromString<ComponentMetadata>(content)
-                        val relativePath = path.substringBeforeLast("/manifest.json")
+                        val normalizedPath = path.replace("\\", "/")
+                        val relativePath = normalizedPath.substringBeforeLast("/manifest.json")
                         metadata.copy(id = relativePath) // Use the full relative path as the unique ID
                     } catch (e: Exception) {
                         null
@@ -141,10 +147,27 @@ fun DevFastToolWindowContent(project: Project) {
         modifier = Modifier.fillMaxSize(),
         first = {
             Column(modifier = Modifier.fillMaxSize()) {
-                Text(
-                    text = "JavaFX Components",
-                    modifier = Modifier.padding(8.dp)
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(text = "JavaFX Components")
+                    if (isRefreshing) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                    } else {
+                        ActionButton(onClick = {
+                            isRefreshing = true
+                            TemplateCache.clearCache()
+                            TemplateLoaderService.getInstance().loadTemplates {
+                                refreshTick++
+                                isRefreshing = false
+                            }
+                        }) {
+                            Text("↻")
+                        }
+                    }
+                }
                 TextField(
                     state = searchState,
                     modifier = Modifier.fillMaxWidth().padding(8.dp),

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -29,6 +29,20 @@ import java.nio.file.Paths
 
 private val json = Json { ignoreUnknownKeys = true }
 
+sealed class TemplateTreeItem {
+    data class Folder(
+        val name: String,
+        val relativePath: String,
+        val children: MutableMap<String, TemplateTreeItem> = mutableMapOf(),
+        var isExpanded: Boolean = false
+    ) : TemplateTreeItem()
+
+    data class Component(
+        val metadata: ComponentMetadata,
+        val relativePath: String
+    ) : TemplateTreeItem()
+}
+
 @Composable
 fun DevFastToolWindowContent(project: Project) {
     val allFiles = remember { TemplateCache.listCachedTemplates() }
@@ -38,34 +52,82 @@ fun DevFastToolWindowContent(project: Project) {
                 TemplateCache.loadTemplate(path)?.let { content ->
                     try {
                         val metadata = json.decodeFromString<ComponentMetadata>(content)
-                        val id = path.substringBeforeLast("/manifest.json").substringAfterLast("/")
-                        metadata.copy(id = id)
+                        val relativePath = path.substringBeforeLast("/manifest.json")
+                        metadata.copy(id = relativePath) // Use the full relative path as the unique ID
                     } catch (e: Exception) {
                         null
                     }
                 }
             }
     }
+
+    val treeRoot = remember(componentsMetadata) {
+        val root = TemplateTreeItem.Folder("", "")
+        for (component in componentsMetadata) {
+            val parts = component.id.split("/")
+            var currentFolder = root
+            for (i in 0 until parts.size - 1) {
+                val folderName = parts[i]
+                val folderPath = parts.take(i + 1).joinToString("/")
+                currentFolder = currentFolder.children.getOrPut(folderName) {
+                    TemplateTreeItem.Folder(folderName, folderPath)
+                } as TemplateTreeItem.Folder
+            }
+            val componentName = parts.last()
+            currentFolder.children[componentName] = TemplateTreeItem.Component(component, component.id)
+        }
+        root
+    }
+
+    var expandedFolders by remember { mutableStateOf(setOf<String>()) }
     var selectedComponent by remember { mutableStateOf<String?>(null) }
     var searchQuery by remember { mutableStateOf("") }
 
     val favoritesService = remember { FavoritesService.getInstance() }
     var favoritesUpdated by remember { mutableLongStateOf(0L) }
 
-    val filteredComponents = remember(componentsMetadata, searchQuery, favoritesUpdated) {
-        val sorted = componentsMetadata.sortedWith(
-            compareByDescending<ComponentMetadata> { favoritesService.isFavorite(it.id) }
-                .thenBy { it.name }
-        )
+    val displayItems = remember(treeRoot, searchQuery, favoritesUpdated, expandedFolders) {
+        val items = mutableListOf<Pair<Int, TemplateTreeItem>>()
 
-        if (searchQuery.isBlank()) {
-            sorted
-        } else {
-            sorted.filter { component ->
-                component.name.contains(searchQuery, ignoreCase = true) ||
-                        component.tags.any { it.contains(searchQuery, ignoreCase = true) }
+        fun addItems(folder: TemplateTreeItem.Folder, depth: Int) {
+            val sortedChildren = folder.children.values.sortedWith { a, b ->
+                when {
+                    a is TemplateTreeItem.Folder && b is TemplateTreeItem.Component -> -1
+                    a is TemplateTreeItem.Component && b is TemplateTreeItem.Folder -> 1
+                    a is TemplateTreeItem.Folder && b is TemplateTreeItem.Folder -> a.name.compareTo(b.name)
+                    a is TemplateTreeItem.Component && b is TemplateTreeItem.Component -> {
+                        val favA = favoritesService.isFavorite(a.metadata.id)
+                        val favB = favoritesService.isFavorite(b.metadata.id)
+                        if (favA != favB) if (favA) -1 else 1
+                        else a.metadata.name.compareTo(b.metadata.name)
+                    }
+                    else -> 0
+                }
+            }
+
+            for (item in sortedChildren) {
+                if (searchQuery.isNotBlank()) {
+                    // In search mode, we flatten everything that matches
+                    if (item is TemplateTreeItem.Component) {
+                        if (item.metadata.name.contains(searchQuery, ignoreCase = true) ||
+                            item.metadata.tags.any { it.contains(searchQuery, ignoreCase = true) }
+                        ) {
+                            items.add(depth to item)
+                        }
+                    } else if (item is TemplateTreeItem.Folder) {
+                        addItems(item, depth)
+                    }
+                } else {
+                    items.add(depth to item)
+                    if (item is TemplateTreeItem.Folder && expandedFolders.contains(item.relativePath)) {
+                        addItems(item, depth + 1)
+                    }
+                }
             }
         }
+
+        addItems(treeRoot, 0)
+        items
     }
 
     val splitLayoutState = rememberSplitLayoutState(0.3f)
@@ -87,25 +149,45 @@ fun DevFastToolWindowContent(project: Project) {
                 )
                 Divider(orientation = Orientation.Horizontal)
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(filteredComponents, key = { it.id }) { component ->
+                    items(displayItems, key = { (it.second as? TemplateTreeItem.Component)?.metadata?.id ?: (it.second as TemplateTreeItem.Folder).relativePath }) { (depth, item) ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { selectedComponent = component.id }
-                                .padding(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(text = component.name, modifier = Modifier.weight(1f))
-
-                            val isFavorite = favoritesService.isFavorite(component.id)
-                            ActionButton(
-                                onClick = {
-                                    favoritesService.toggleFavorite(component.id)
-                                    favoritesUpdated++
+                                .clickable {
+                                    if (item is TemplateTreeItem.Folder) {
+                                        expandedFolders = if (expandedFolders.contains(item.relativePath)) {
+                                            expandedFolders - item.relativePath
+                                        } else {
+                                            expandedFolders + item.relativePath
+                                        }
+                                    } else if (item is TemplateTreeItem.Component) {
+                                        selectedComponent = item.metadata.id
+                                    }
                                 }
-                            ) {
-                                Text(if (isFavorite) "★" else "☆")
+                                .padding(vertical = 4.dp, horizontal = 8.dp)
+                                .padding(start = (depth * 16).dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Start
+                        ) {
+                            if (item is TemplateTreeItem.Folder) {
+                                Text(
+                                    text = if (expandedFolders.contains(item.relativePath)) "▼" else "▶",
+                                    modifier = Modifier.padding(end = 4.dp)
+                                )
+                                Text(text = item.name, modifier = Modifier.weight(1f))
+                            } else if (item is TemplateTreeItem.Component) {
+                                Spacer(modifier = Modifier.width(20.dp))
+                                Text(text = item.metadata.name, modifier = Modifier.weight(1f))
+
+                                val isFavorite = favoritesService.isFavorite(item.metadata.id)
+                                ActionButton(
+                                    onClick = {
+                                        favoritesService.toggleFavorite(item.metadata.id)
+                                        favoritesUpdated++
+                                    }
+                                ) {
+                                    Text(if (isFavorite) "★" else "☆")
+                                }
                             }
                         }
                     }

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -205,7 +205,8 @@ fun DevFastToolWindowContent(project: Project) {
 
                 val readmePath = allFiles.find {
                     val normalizedPath = it.replace("\\", "/")
-                    normalizedPath.startsWith(normalizedSelectedId) && normalizedPath.endsWith("README.md")
+                    val parentDir = if (normalizedPath.contains("/")) normalizedPath.substringBeforeLast("/") else ""
+                    parentDir == normalizedSelectedId && normalizedPath.endsWith("README.md")
                 }
                 if (readmePath != null) {
                     val readmeContent = TemplateCache.loadTemplate(readmePath)

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -24,6 +24,8 @@ import org.jetbrains.jewel.ui.component.HorizontalSplitLayout
 import kotlinx.serialization.json.Json
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextField
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import org.jetbrains.jewel.ui.component.rememberSplitLayoutState
 import java.nio.file.Paths
 
@@ -64,7 +66,8 @@ fun DevFastToolWindowContent(project: Project) {
     val treeRoot = remember(componentsMetadata) {
         val root = TemplateTreeItem.Folder("", "")
         for (component in componentsMetadata) {
-            val parts = component.id.split("/")
+            val normalizedId = component.id.replace("\\", "/")
+            val parts = normalizedId.split("/")
             var currentFolder = root
             for (i in 0 until parts.size - 1) {
                 val folderName = parts[i]
@@ -74,20 +77,21 @@ fun DevFastToolWindowContent(project: Project) {
                 } as TemplateTreeItem.Folder
             }
             val componentName = parts.last()
-            currentFolder.children[componentName] = TemplateTreeItem.Component(component, component.id)
+            currentFolder.children[componentName] = TemplateTreeItem.Component(component, normalizedId)
         }
         root
     }
 
     var expandedFolders by remember { mutableStateOf(setOf<String>()) }
     var selectedComponent by remember { mutableStateOf<String?>(null) }
-    var searchQuery by remember { mutableStateOf("") }
+    val searchState = rememberTextFieldState("")
 
     val favoritesService = remember { FavoritesService.getInstance() }
     var favoritesUpdated by remember { mutableLongStateOf(0L) }
 
-    val displayItems = remember(treeRoot, searchQuery, favoritesUpdated, expandedFolders) {
+    val displayItems = remember(treeRoot, searchState.text, favoritesUpdated, expandedFolders) {
         val items = mutableListOf<Pair<Int, TemplateTreeItem>>()
+        val searchQuery = searchState.text.toString()
 
         fun addItems(folder: TemplateTreeItem.Folder, depth: Int) {
             val sortedChildren = folder.children.values.sortedWith { a, b ->
@@ -142,8 +146,7 @@ fun DevFastToolWindowContent(project: Project) {
                     modifier = Modifier.padding(8.dp)
                 )
                 TextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
+                    state = searchState,
                     modifier = Modifier.fillMaxWidth().padding(8.dp),
                     placeholder = { Text("Search components...") }
                 )
@@ -196,10 +199,14 @@ fun DevFastToolWindowContent(project: Project) {
         },
         second = {
             if (selectedComponent != null) {
-                val componentDirPath = Paths.get(PathManager.getSystemPath(), "devFastJavaFx/templates", selectedComponent!!)
-                val markdownParser = remember(selectedComponent) { MarkdownParser(componentDirPath) }
+                val normalizedSelectedId = selectedComponent!!.replace("\\", "/")
+                val componentDirPath = Paths.get(PathManager.getSystemPath(), "devFastJavaFx/templates", normalizedSelectedId)
+                val markdownParser = remember(normalizedSelectedId) { MarkdownParser(componentDirPath) }
 
-                val readmePath = allFiles.find { it.contains(selectedComponent!!) && it.endsWith("README.md") }
+                val readmePath = allFiles.find {
+                    val normalizedPath = it.replace("\\", "/")
+                    normalizedPath.startsWith(normalizedSelectedId) && normalizedPath.endsWith("README.md")
+                }
                 if (readmePath != null) {
                     val readmeContent = TemplateCache.loadTemplate(readmePath)
                     if (readmeContent != null) {

--- a/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownParser.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/markdown/MarkdownParser.kt
@@ -37,19 +37,39 @@ class MarkdownParser(private val componentDirectory: Path) {
                 blocks.add(MarkdownBlock.Heading(node.text.toString(), node.level))
             }
             is Paragraph -> {
-                val text = node.chars.toString().trim()
-                when {
-                    text.startsWith("@[code](") && text.endsWith(")") -> {
-                        val filename = text.substringAfter("@[code](").substringBeforeLast(")")
-                        blocks.add(resolveCodeBlock(filename))
+                val rawText = node.chars.toString()
+                val lines = rawText.lines()
+                val textLines = mutableListOf<String>()
+
+                for (line in lines) {
+                    val trimmed = line.trim()
+                    when {
+                        trimmed.startsWith("@[code](") && trimmed.endsWith(")") -> {
+                            // Flush accumulated text lines first
+                            if (textLines.isNotEmpty()) {
+                                val joined = textLines.joinToString("\n").trim()
+                                if (joined.isNotBlank()) blocks.add(MarkdownBlock.Text(renderInlines(node, joined)))
+                                textLines.clear()
+                            }
+                            val filename = trimmed.substringAfter("@[code](").substringBeforeLast(")")
+                            blocks.add(resolveCodeBlock(filename))
+                        }
+                        trimmed.startsWith("@[plantuml](") && trimmed.endsWith(")") -> {
+                            if (textLines.isNotEmpty()) {
+                                val joined = textLines.joinToString("\n").trim()
+                                if (joined.isNotBlank()) blocks.add(MarkdownBlock.Text(renderInlines(node, joined)))
+                                textLines.clear()
+                            }
+                            val filename = trimmed.substringAfter("@[plantuml](").substringBeforeLast(")")
+                            blocks.add(resolvePlantUmlBlock(filename))
+                        }
+                        else -> textLines.add(line)
                     }
-                    text.startsWith("@[plantuml](") && text.endsWith(")") -> {
-                        val filename = text.substringAfter("@[plantuml](").substringBeforeLast(")")
-                        blocks.add(resolvePlantUmlBlock(filename))
-                    }
-                    else -> {
-                        blocks.add(MarkdownBlock.Text(renderInlines(node)))
-                    }
+                }
+                // Flush remaining text
+                if (textLines.isNotEmpty()) {
+                    val joined = textLines.joinToString("\n").trim()
+                    if (joined.isNotBlank()) blocks.add(MarkdownBlock.Text(renderInlines(node, joined)))
                 }
             }
             is FencedCodeBlock -> {
@@ -89,6 +109,10 @@ class MarkdownParser(private val componentDirectory: Path) {
             }
             child = child.next
         }
+    }
+
+    private fun renderInlines(node: Node, plainText: String): AnnotatedString = buildAnnotatedString {
+        append(plainText)
     }
 
     private fun resolveCodeBlock(filename: String): MarkdownBlock {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,11 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.example.devfastjavafx.service.FavoritesService"/>
+        <applicationService serviceImplementation="com.example.devfastjavafx.settings.GitLabSettingsState"/>
+        <applicationConfigurable instance="com.example.devfastjavafx.settings.GitLabSettingsConfigurable"
+                                 id="com.example.devfastjavafx.settings.GitLabSettingsConfigurable"
+                                 displayName="DevFast GitLab Settings"
+                                 parentId="tools"/>
         <postStartupActivity implementation="com.example.devfastjavafx.activity.TemplateStartupActivity"/>
         <toolWindow id="DevFastJavaFx" anchor="right" factoryClass="com.example.devfastjavafx.ui.DevFastToolWindowFactory" />
     </extensions>


### PR DESCRIPTION
This PR introduces a dedicated settings page for the DevFast plugin to configure GitLab connection details.

Key changes:
- **GitLabSettingsState**: A new persistent state component to store the GitLab base URL and Project ID.
- **GitLabSettingsComponent**: The UI for the settings page, built using modern Kotlin UI DSL v2. It includes fields for the URL, Project ID, and a masked password field for the Personal Access Token.
- **GitLabSettingsConfigurable**: Bridges the UI and the persistent state, ensuring that settings are applied and reset correctly. It also handles the secure storage of the Personal Access Token via `GitLabCredentialsManager` (using the IntelliJ PasswordSafe API).
- **TemplateLoaderService Refactoring**: Updated the service to dynamically fetch connection details from the settings at runtime, replacing previous hardcoded values.
- **Dependency Update**: Added `kotlinx-serialization-json` to `build.gradle.kts` to resolve compilation issues.

The settings menu can be found under 'Settings > Tools > DevFast GitLab Settings'.

Fixes #19

---
*PR created automatically by Jules for task [2944786061931723208](https://jules.google.com/task/2944786061931723208) started by @tkpixel*