### PR TITLE
Add Favorites Tab to Tool Window

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:2.3.7")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.7")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     implementation("com.vladsch.flexmark:flexmark-all:0.64.8")
     implementation("net.sourceforge.plantuml:plantuml:1.2023.12")

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowContent.kt
@@ -30,7 +30,7 @@ import java.nio.file.Paths
 private val json = Json { ignoreUnknownKeys = true }
 
 @Composable
-fun DevFastToolWindowContent(project: Project) {
+fun DevFastToolWindowContent(project: Project, showOnlyFavorites: Boolean = false) {
     val allFiles = remember { TemplateCache.listCachedTemplates() }
     val componentsMetadata = remember(allFiles) {
         allFiles.filter { it.endsWith("manifest.json") }
@@ -52,16 +52,20 @@ fun DevFastToolWindowContent(project: Project) {
     val favoritesService = remember { FavoritesService.getInstance() }
     var favoritesUpdated by remember { mutableLongStateOf(0L) }
 
-    val filteredComponents = remember(componentsMetadata, searchQuery, favoritesUpdated) {
-        val sorted = componentsMetadata.sortedWith(
-            compareByDescending<ComponentMetadata> { favoritesService.isFavorite(it.id) }
-                .thenBy { it.name }
-        )
+    val filteredComponents = remember(componentsMetadata, searchQuery, favoritesUpdated, showOnlyFavorites) {
+        val baseList = if (showOnlyFavorites) {
+            componentsMetadata.filter { favoritesService.isFavorite(it.id) }.sortedBy { it.name }
+        } else {
+            componentsMetadata.sortedWith(
+                compareByDescending<ComponentMetadata> { favoritesService.isFavorite(it.id) }
+                    .thenBy { it.name }
+            )
+        }
 
         if (searchQuery.isBlank()) {
-            sorted
+            baseList
         } else {
-            sorted.filter { component ->
+            baseList.filter { component ->
                 component.name.contains(searchQuery, ignoreCase = true) ||
                         component.tags.any { it.contains(searchQuery, ignoreCase = true) }
             }

--- a/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowFactory.kt
+++ b/src/main/kotlin/com/example/devfastjavafx/ui/DevFastToolWindowFactory.kt
@@ -10,5 +10,8 @@ class DevFastToolWindowFactory : ToolWindowFactory {
         toolWindow.addComposeTab("Templates") {
             DevFastToolWindowContent(project)
         }
+        toolWindow.addComposeTab("Favorites") {
+            DevFastToolWindowContent(project, showOnlyFavorites = true)
+        }
     }
 }


### PR DESCRIPTION
This PR adds a "Favorites" tab in the tool window right next to the "Templates" tab. The new tab displays only templates that are marked as a favorite. It filters the existing component metadata using the `FavoritesService` and retains the existing search functionality. Also included a fix to explicitly depend on `kotlinx-serialization-json` for building successfully.

---
*PR created automatically by Jules for task [14573256474763006984](https://jules.google.com/task/14573256474763006984) started by @tkpixel*